### PR TITLE
Fixed DateFormat that doesn't for Java <= 1.6

### DIFF
--- a/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/OsgiBundleConfigurer.groovy
+++ b/libs/wuff-plugin/src/main/groovy/org/akhikhl/wuff/OsgiBundleConfigurer.groovy
@@ -33,7 +33,7 @@ class OsgiBundleConfigurer extends JavaConfigurer {
       current_os: PlatformConfig.current_os,
       current_arch: PlatformConfig.current_arch,
       current_language: PlatformConfig.current_language ]
-    snapshotQualifier = '.' + (new Date().format('YYYYMMddHHmm'))
+    snapshotQualifier = '.' + (new Date().format('yyyyMMddHHmm'))
   }
 
   @Override


### PR DESCRIPTION
The "Y"s in `YYYYMMddHHmm` are defined as [week years](http://docs.oracle.com/javase/7/docs/api/java/util/GregorianCalendar.html#week_year) and were only introduced in Java 1.7

This means that you cannot use JDK 1.6 to build Wuff projects. (Don't ask :frowning: )

It fails with:

```
Caused by: java.lang.IllegalArgumentException: Illegal pattern character 'Y'
    at org.akhikhl.wuff.OsgiBundleConfigurer.<init>(OsgiBundleConfigurer.groovy:36)
    at org.akhikhl.wuff.EquinoxAppConfigurer.<init>(EquinoxAppConfigurer.groovy:22)
    at org.akhikhl.wuff.EclipseRcpAppConfigurer.<init>(EclipseRcpAppConfigurer.groovy:21)
    at org.akhikhl.wuff.EclipseRcpAppPlugin.apply(EclipseRcpAppPlugin.groovy:22)
    at org.akhikhl.wuff.EclipseRcpAppPlugin.apply(EclipseRcpAppPlugin.groovy)
    at org.gradle.api.internal.plugins.ImperativeOnlyPluginApplicator.applyImperative(ImperativeOnlyPluginApplicator.java:35)
    at org.gradle.api.internal.plugins.RuleBasedPluginApplicator.applyImperative(RuleBasedPluginApplicator.java:43)
    at org.gradle.api.internal.plugins.DefaultPluginManager.doApply(DefaultPluginManager.java:144)
    ... 49 more
BUILD FAILED
```

Unless there is a specific reason why week years (YYYYMMddHHmm) should be used instead of normal years (yyyyMMddHHmm), I recommend that this date pattern is changed.

See here for more info:
http://stackoverflow.com/questions/8686331/y-returns-2012-while-y-returns-2011-in-simpledateformat
http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html
http://stackoverflow.com/questions/8686331/y-returns-2012-while-y-returns-2011-in-simpledateformat
